### PR TITLE
chore(#31): gitignore .claude/ to keep ApexYard session markers out of commits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,6 @@ Thumbs.db
 *.sqlite
 *.sqlite3
 downloaded_files/
+
+# ApexYard session state (markers, etc.)
+.claude/


### PR DESCRIPTION
## Summary

- Adds `.claude/` to `.gitignore` so ApexYard session state (per-PR Rex/CEO approval markers, active-ticket markers, etc.) cannot accidentally enter version control.

## Why now

The athletiq-prototype repo is governed under ApexYard (`me2resh/apexyard`). ApexYard writes per-machine, per-clone state to `.claude/session/`. This includes:

- `.claude/session/reviews/<pr>-rex.approved` — Rex's per-PR approval marker (HEAD SHA)
- `.claude/session/reviews/<pr>-ceo.approved` — CEO's per-PR merge approval marker (HEAD SHA)
- `.claude/session/tickets/athletiq-prototype` — active ticket marker for this project's session

These are gitignored already in the apexyard ops fork; they should be gitignored here too. Without this PR they sit untracked-but-visible in `git status`, one slip on `git add -A` away from leaking.

The leak would be cosmetic (no secrets, no PII) but it would create cross-machine confusion and clutter PRs. Cheap to prevent.

## Test plan

- [ ] After merge, `git status` from a clone with active ApexYard markers shows nothing related to `.claude/`
- [ ] `git ls-files | grep -E '\.claude/'` returns nothing in this repo

## Glossary

| Term | Definition |
|------|------------|
| **ApexYard** | Multi-project SDLC framework managing this repo (`me2resh/apexyard`) |
| **`.claude/session/`** | Per-machine session state directory used by ApexYard hooks (active-ticket marker, per-PR review approvals) |

Refs #31

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moussaws/athletiq-prototype/pull/32" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
